### PR TITLE
Add basic HTTP server implementation

### DIFF
--- a/include/http/HttpContext.h
+++ b/include/http/HttpContext.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "http/HttpRequest.h"
+
+class Buffer;
+class TimeStamp;
+
+class HttpContext {
+public:
+    enum HttpRequestParseState {
+        kExpectRequestLine,
+        kExpectHeaders,
+        kExpectBody,
+        kGotAll,
+    };
+
+    HttpContext() : state_(kExpectRequestLine) {}
+
+    bool parseRequest(Buffer* buf, TimeStamp receiveTime);
+
+    bool gotAll() const { return state_ == kGotAll; }
+    void reset();
+
+    const HttpRequest& request() const { return request_; }
+    HttpRequest& request() { return request_; }
+
+private:
+    bool processRequestLine(const char* begin, const char* end);
+
+    HttpRequestParseState state_;
+    HttpRequest request_;
+};

--- a/include/http/HttpRequest.h
+++ b/include/http/HttpRequest.h
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+class HttpRequest {
+public:
+    enum Method {
+        kInvalid,
+        kGet,
+        kPost,
+        kHead,
+        kPut,
+        kDelete,
+    };
+
+    enum Version {
+        kUnknown,
+        kHttp10,
+        kHttp11,
+    };
+
+    HttpRequest() : method_(kInvalid), version_(kUnknown) {}
+
+    void setVersion(Version v) { version_ = v; }
+    Version version() const { return version_; }
+
+    bool setMethod(const char* start, const char* end);
+    Method method() const { return method_; }
+    const char* methodString() const;
+
+    void setPath(const char* start, const char* end) { path_.assign(start, end); }
+    const std::string& path() const { return path_; }
+
+    void setQuery(const char* start, const char* end) { query_.assign(start, end); }
+    const std::string& query() const { return query_; }
+
+    void addHeader(const char* start, const char* colon, const char* end);
+    std::string getHeader(const std::string& field) const;
+
+    const std::map<std::string, std::string>& headers() const { return headers_; }
+
+    void swap(HttpRequest& that);
+
+private:
+    Method method_;
+    Version version_;
+    std::string path_;
+    std::string query_;
+    std::map<std::string, std::string> headers_;
+};

--- a/include/http/HttpResponse.h
+++ b/include/http/HttpResponse.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <map>
+#include <string>
+
+class Buffer;
+
+class HttpResponse {
+public:
+    enum HttpStatusCode {
+        kUnknown,
+        k200Ok = 200,
+        k301MovedPermanently = 301,
+        k400BadRequest = 400,
+        k404NotFound = 404,
+    };
+
+    explicit HttpResponse(bool close);
+
+    void setStatusCode(HttpStatusCode code) { statusCode_ = code; }
+    void setStatusMessage(const std::string& message) { statusMessage_ = message; }
+
+    void setCloseConnection(bool on) { closeConnection_ = on; }
+    bool closeConnection() const { return closeConnection_; }
+
+    void setContentType(const std::string& contentType) { addHeader("Content-Type", contentType); }
+    void addHeader(const std::string& key, const std::string& value) { headers_[key] = value; }
+
+    void setBody(const std::string& body) { body_ = body; }
+
+    void appendToBuffer(Buffer* output) const;
+
+private:
+    HttpStatusCode statusCode_;
+    std::string statusMessage_;
+    std::map<std::string, std::string> headers_;
+    std::string body_;
+    bool closeConnection_;
+};

--- a/include/http/HttpServer.h
+++ b/include/http/HttpServer.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+#include "TcpServer.h"
+#include "http/HttpContext.h"
+#include "http/HttpResponse.h"
+
+class HttpServer {
+public:
+    using HttpCallback = std::function<void(const HttpRequest&, HttpResponse*)>;
+
+    HttpServer(EventLoop* loop, const InetAddress& listenAddr, const std::string& name, TcpServer::Option option = TcpServer::kNoReusePort);
+
+    void setHttpCallback(const HttpCallback& cb) { httpCallback_ = cb; }
+
+    void setThreadNum(int numThreads) { server_.setThreadNum(numThreads); }
+    void start();
+
+private:
+    void onConnection(const TcpConnectionPtr& conn);
+    void onMessage(const TcpConnectionPtr& conn, Buffer* buf, TimeStamp receiveTime);
+    void onRequest(const TcpConnectionPtr& conn, const HttpRequest& req);
+
+    TcpServer server_;
+    HttpCallback httpCallback_;
+    std::unordered_map<TcpConnection*, HttpContext> contexts_;
+};

--- a/src/HttpContext.cpp
+++ b/src/HttpContext.cpp
@@ -1,0 +1,93 @@
+#include "http/HttpContext.h"
+
+#include <algorithm>
+
+#include "Buffer.h"
+#include "TimeStamp.h"
+
+namespace {
+const char kCRLF[] = "\r\n";
+}
+
+void HttpContext::reset() {
+    state_ = kExpectRequestLine;
+    HttpRequest dummy;
+    request_.swap(dummy);
+}
+
+bool HttpContext::processRequestLine(const char* begin, const char* end) {
+    const char* start = begin;
+    const char* space = std::find(start, end, ' ');
+    if (space == end)
+        return false;
+    if (!request_.setMethod(start, space))
+        return false;
+    start = space + 1;
+    space = std::find(start, end, ' ');
+    const char* question = std::find(start, space, '?');
+    if (question != space) {
+        request_.setPath(start, question);
+        request_.setQuery(question + 1, space);
+    } else {
+        request_.setPath(start, space);
+    }
+    start = space + 1;
+    if (end - start == 8 && std::equal(start, end - 1, "HTTP/1.")) {
+        if (*(end - 1) == '1') {
+            request_.setVersion(HttpRequest::kHttp11);
+        } else if (*(end - 1) == '0') {
+            request_.setVersion(HttpRequest::kHttp10);
+        } else {
+            return false;
+        }
+    } else {
+        return false;
+    }
+    return true;
+}
+
+bool HttpContext::parseRequest(Buffer* buf, TimeStamp /*receiveTime*/) {
+    bool ok = true;
+    bool hasMore = true;
+    while (hasMore) {
+        if (state_ == kExpectRequestLine) {
+            size_t readable = buf->readableBytes();
+            const char* start = buf->peek();
+            const char* crlf = std::search(start, start + readable, kCRLF, kCRLF + 2);
+            if (crlf != start + readable) {
+                if (processRequestLine(start, crlf)) {
+                    state_ = kExpectHeaders;
+                    buf->retrieve(crlf + 2 - start);
+                } else {
+                    ok = false;
+                    hasMore = false;
+                }
+            } else {
+                hasMore = false;
+            }
+        } else if (state_ == kExpectHeaders) {
+            size_t readable = buf->readableBytes();
+            const char* start = buf->peek();
+            const char* crlf = std::search(start, start + readable, kCRLF, kCRLF + 2);
+            if (crlf != start + readable) {
+                const char* colon = std::find(start, crlf, ':');
+                if (colon != crlf) {
+                    request_.addHeader(start, colon, crlf);
+                } else {
+                    state_ = kGotAll;
+                    hasMore = false;
+                }
+                buf->retrieve(crlf + 2 - start);
+            } else {
+                hasMore = false;
+            }
+        } else if (state_ == kExpectBody) {
+            // not implemented
+            state_ = kGotAll;
+            hasMore = false;
+        } else {
+            hasMore = false;
+        }
+    }
+    return ok;
+}

--- a/src/HttpRequest.cpp
+++ b/src/HttpRequest.cpp
@@ -1,0 +1,64 @@
+#include "http/HttpRequest.h"
+
+#include <algorithm>
+#include <cctype>
+
+void HttpRequest::swap(HttpRequest& that) {
+    std::swap(method_, that.method_);
+    std::swap(version_, that.version_);
+    path_.swap(that.path_);
+    query_.swap(that.query_);
+    headers_.swap(that.headers_);
+}
+
+bool HttpRequest::setMethod(const char* start, const char* end) {
+    std::string m(start, end);
+    if (m == "GET")
+        method_ = kGet;
+    else if (m == "POST")
+        method_ = kPost;
+    else if (m == "HEAD")
+        method_ = kHead;
+    else if (m == "PUT")
+        method_ = kPut;
+    else if (m == "DELETE")
+        method_ = kDelete;
+    else
+        method_ = kInvalid;
+    return method_ != kInvalid;
+}
+
+const char* HttpRequest::methodString() const {
+    switch (method_) {
+    case kGet:
+        return "GET";
+    case kPost:
+        return "POST";
+    case kHead:
+        return "HEAD";
+    case kPut:
+        return "PUT";
+    case kDelete:
+        return "DELETE";
+    default:
+        return "UNKNOWN";
+    }
+}
+
+void HttpRequest::addHeader(const char* start, const char* colon, const char* end) {
+    std::string field(start, colon);
+    ++colon;
+    while (colon < end && isspace(*colon))
+        ++colon;
+    std::string value(colon, end);
+    while (!value.empty() && isspace(value.back()))
+        value.pop_back();
+    headers_[field] = value;
+}
+
+std::string HttpRequest::getHeader(const std::string& field) const {
+    auto it = headers_.find(field);
+    if (it != headers_.end())
+        return it->second;
+    return "";
+}

--- a/src/HttpResponse.cpp
+++ b/src/HttpResponse.cpp
@@ -1,0 +1,34 @@
+#include "http/HttpResponse.h"
+
+#include <cstdio>
+#include <cstring>
+
+#include "Buffer.h"
+
+HttpResponse::HttpResponse(bool close) : statusCode_(kUnknown), closeConnection_(close) {}
+
+void HttpResponse::appendToBuffer(Buffer* output) const {
+    char buf[64];
+    snprintf(buf, sizeof buf, "HTTP/1.1 %d ", statusCode_);
+    output->append(buf, strlen(buf));
+    output->append(statusMessage_.c_str(), statusMessage_.size());
+    output->append("\r\n", 2);
+
+    if (closeConnection_) {
+        output->append("Connection: close\r\n", 19);
+    } else {
+        snprintf(buf, sizeof buf, "Content-Length: %zu\r\n", body_.size());
+        output->append(buf, strlen(buf));
+        output->append("Connection: Keep-Alive\r\n", 24);
+    }
+
+    for (const auto& header : headers_) {
+        output->append(header.first.c_str(), header.first.size());
+        output->append(": ", 2);
+        output->append(header.second.c_str(), header.second.size());
+        output->append("\r\n", 2);
+    }
+
+    output->append("\r\n", 2);
+    output->append(body_.c_str(), body_.size());
+}

--- a/src/HttpServer.cpp
+++ b/src/HttpServer.cpp
@@ -1,0 +1,59 @@
+#include "http/HttpServer.h"
+
+#include "Buffer.h"
+#include "Logger.h"
+
+HttpServer::HttpServer(EventLoop* loop, const InetAddress& listenAddr, const std::string& name, TcpServer::Option option) : server_(loop, listenAddr, name, option) {
+    server_.setConnectionCallback([this](const TcpConnectionPtr& conn) { onConnection(conn); });
+    server_.setMessageCallback([this](const TcpConnectionPtr& conn, Buffer* buf, TimeStamp time) { onMessage(conn, buf, time); });
+}
+
+void HttpServer::start() {
+    server_.start();
+}
+
+void HttpServer::onConnection(const TcpConnectionPtr& conn) {
+    if (conn->connected()) {
+        contexts_.emplace(conn.get(), HttpContext());
+    } else {
+        contexts_.erase(conn.get());
+    }
+}
+
+void HttpServer::onMessage(const TcpConnectionPtr& conn, Buffer* buf, TimeStamp receiveTime) {
+    auto it = contexts_.find(conn.get());
+    if (it == contexts_.end()) {
+        HttpContext ctx;
+        it = contexts_.emplace(conn.get(), std::move(ctx)).first;
+    }
+    HttpContext& context = it->second;
+    if (!context.parseRequest(buf, receiveTime)) {
+        conn->send("HTTP/1.1 400 Bad Request\r\n\r\n");
+        conn->shutdown();
+    }
+    if (context.gotAll()) {
+        onRequest(conn, context.request());
+        context.reset();
+    }
+}
+
+void HttpServer::onRequest(const TcpConnectionPtr& conn, const HttpRequest& req) {
+    bool close = false;
+    if (req.getHeader("Connection") == "close" || (req.version() == HttpRequest::kHttp10 && req.getHeader("Connection") != "Keep-Alive")) {
+        close = true;
+    }
+    HttpResponse response(close);
+    if (httpCallback_) {
+        httpCallback_(req, &response);
+    } else {
+        response.setStatusCode(HttpResponse::k404NotFound);
+        response.setStatusMessage("Not Found");
+        response.setCloseConnection(true);
+    }
+    Buffer buf;
+    response.appendToBuffer(&buf);
+    conn->send(buf.retrieveAllAsString());
+    if (response.closeConnection()) {
+        conn->shutdown();
+    }
+}


### PR DESCRIPTION
## Summary
- implement HttpRequest, HttpResponse, HttpContext, and HttpServer classes for handling simple HTTP traffic
- integrate new HTTP components with existing TcpServer

## Testing
- `cmake ..`
- `make -j4`

------
https://chatgpt.com/codex/tasks/task_e_68bda8290a8c8327892495170d55354e