### PR TITLE
Add basic KCP and QUIC server/session skeletons

### DIFF
--- a/include/kcp/KcpSession.h
+++ b/include/kcp/KcpSession.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <memory>
+
+#include "InetAddress.h"
+#include "NonCopyable.h"
+
+// Forward declaration for KCP control block
+struct IKCPCB;
+
+// Basic session for KCP over UDP
+class KcpSession : NonCopyable, public std::enable_shared_from_this<KcpSession> {
+public:
+    KcpSession(int sockfd, const InetAddress& peer);
+    ~KcpSession();
+
+    // send data to peer using underlying UDP socket
+    void send(const char* data, size_t len);
+
+    const InetAddress& peerAddr() const { return peer_; }
+
+private:
+    int sockfd_;
+    InetAddress peer_;
+    IKCPCB* kcp_;  // placeholder for future KCP control block
+};

--- a/include/quic/QuicServer.h
+++ b/include/quic/QuicServer.h
@@ -9,17 +9,16 @@
 #include "NonCopyable.h"
 #include "TimeStamp.h"
 
-class KcpSession;
+class QuicSession;
 
-// Basic KCP server built on UDP and EventLoop
-class KcpServer : NonCopyable {
+// Simplified QUIC server built on UDP; acts as placeholder for real QUIC
+class QuicServer : NonCopyable {
 public:
-    using SessionPtr = std::shared_ptr<KcpSession>;
+    using SessionPtr = std::shared_ptr<QuicSession>;
 
-    KcpServer(EventLoop* loop, const InetAddress& listenAddr);
-    ~KcpServer();
+    QuicServer(EventLoop* loop, const InetAddress& listenAddr);
+    ~QuicServer();
 
-    // Start receiving datagrams
     void start();
 
 private:

--- a/include/quic/QuicSession.h
+++ b/include/quic/QuicSession.h
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <memory>
+
+#include "InetAddress.h"
+#include "NonCopyable.h"
+
+// Simplified QUIC session placeholder
+class QuicSession : NonCopyable, public std::enable_shared_from_this<QuicSession> {
+public:
+    QuicSession(int sockfd, const InetAddress& peer);
+    ~QuicSession();
+
+    void send(const char* data, size_t len);
+
+    const InetAddress& peerAddr() const { return peer_; }
+
+private:
+    int sockfd_;
+    InetAddress peer_;
+};

--- a/src/KcpServer.cpp
+++ b/src/KcpServer.cpp
@@ -1,0 +1,47 @@
+#include "kcp/KcpServer.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "Logger.h"
+#include "kcp/KcpSession.h"
+
+KcpServer::KcpServer(EventLoop* loop, const InetAddress& listenAddr) : loop_(loop), sockfd_(::socket(AF_INET, SOCK_DGRAM, 0)), listenAddr_(listenAddr), channel_(loop, sockfd_) {
+    ::bind(sockfd_, reinterpret_cast<const sockaddr*>(listenAddr_.getSockAddr()), sizeof(sockaddr_in));
+    channel_.setReadCallback(std::bind(&KcpServer::handleRead, this, std::placeholders::_1));
+}
+
+KcpServer::~KcpServer() {
+    ::close(sockfd_);
+}
+
+void KcpServer::start() {
+    channel_.enableReading();
+}
+
+void KcpServer::handleRead(TimeStamp /*receiveTime*/) {
+    char buf[4096];
+    sockaddr_in peeraddr;
+    socklen_t len = sizeof(peeraddr);
+    ssize_t n = ::recvfrom(sockfd_, buf, sizeof(buf), 0, reinterpret_cast<sockaddr*>(&peeraddr), &len);
+    if (n <= 0) {
+        return;
+    }
+    InetAddress peer(peeraddr);
+    SessionPtr session = getSession(peer);
+    // In real KCP, input would parse data. Here we simply echo back.
+    session->send(buf, static_cast<size_t>(n));
+}
+
+KcpServer::SessionPtr KcpServer::getSession(const InetAddress& peer) {
+    std::string key = peer.toIpPort();
+    auto it = sessions_.find(key);
+    if (it != sessions_.end()) {
+        return it->second;
+    }
+    SessionPtr session = std::make_shared<KcpSession>(sockfd_, peer);
+    sessions_[key] = session;
+    return session;
+}

--- a/src/KcpSession.cpp
+++ b/src/KcpSession.cpp
@@ -1,0 +1,13 @@
+#include "kcp/KcpSession.h"
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+KcpSession::KcpSession(int sockfd, const InetAddress& peer) : sockfd_(sockfd), peer_(peer), kcp_(nullptr) {}
+
+KcpSession::~KcpSession() = default;
+
+void KcpSession::send(const char* data, size_t len) {
+    ::sendto(sockfd_, data, len, 0, reinterpret_cast<const sockaddr*>(peer_.getSockAddr()), sizeof(sockaddr_in));
+}

--- a/src/QuicServer.cpp
+++ b/src/QuicServer.cpp
@@ -1,0 +1,47 @@
+#include "quic/QuicServer.h"
+
+#include <arpa/inet.h>
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include "Logger.h"
+#include "quic/QuicSession.h"
+
+QuicServer::QuicServer(EventLoop* loop, const InetAddress& listenAddr) : loop_(loop), sockfd_(::socket(AF_INET, SOCK_DGRAM, 0)), listenAddr_(listenAddr), channel_(loop, sockfd_) {
+    ::bind(sockfd_, reinterpret_cast<const sockaddr*>(listenAddr_.getSockAddr()), sizeof(sockaddr_in));
+    channel_.setReadCallback(std::bind(&QuicServer::handleRead, this, std::placeholders::_1));
+}
+
+QuicServer::~QuicServer() {
+    ::close(sockfd_);
+}
+
+void QuicServer::start() {
+    channel_.enableReading();
+}
+
+void QuicServer::handleRead(TimeStamp /*receiveTime*/) {
+    char buf[4096];
+    sockaddr_in peeraddr;
+    socklen_t len = sizeof(peeraddr);
+    ssize_t n = ::recvfrom(sockfd_, buf, sizeof(buf), 0, reinterpret_cast<sockaddr*>(&peeraddr), &len);
+    if (n <= 0) {
+        return;
+    }
+    InetAddress peer(peeraddr);
+    SessionPtr session = getSession(peer);
+    // Placeholder for QUIC handling; echo back for now.
+    session->send(buf, static_cast<size_t>(n));
+}
+
+QuicServer::SessionPtr QuicServer::getSession(const InetAddress& peer) {
+    std::string key = peer.toIpPort();
+    auto it = sessions_.find(key);
+    if (it != sessions_.end()) {
+        return it->second;
+    }
+    SessionPtr session = std::make_shared<QuicSession>(sockfd_, peer);
+    sessions_[key] = session;
+    return session;
+}

--- a/src/QuicSession.cpp
+++ b/src/QuicSession.cpp
@@ -1,0 +1,13 @@
+#include "quic/QuicSession.h"
+
+#include <netinet/in.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+QuicSession::QuicSession(int sockfd, const InetAddress& peer) : sockfd_(sockfd), peer_(peer) {}
+
+QuicSession::~QuicSession() = default;
+
+void QuicSession::send(const char* data, size_t len) {
+    ::sendto(sockfd_, data, len, 0, reinterpret_cast<const sockaddr*>(peer_.getSockAddr()), sizeof(sockaddr_in));
+}


### PR DESCRIPTION
## Summary
- add foundational KcpServer and KcpSession classes for UDP-based communication
- introduce placeholder QuicServer and QuicSession wrappers ready for future QUIC features

## Testing
- `cmake .. && make -j4`


------
https://chatgpt.com/codex/tasks/task_e_68be31e2196c8327b4550527637c1045